### PR TITLE
Fix typo in GitHub Pages sentence

### DIFF
--- a/github-pages.md
+++ b/github-pages.md
@@ -1,6 +1,6 @@
 ## Static hosting: GitHub Pages
 
-[GitHub Pages](https://pages.github.com/) is a free hosting service that turns your GitHub repository directly into a whenever you push it. This is useful for sharing analysis results, data science portfolios, project documentation, and more.
+[GitHub Pages](https://pages.github.com/) is a free hosting service that turns your GitHub repository directly into a static website whenever you push it. This is useful for sharing analysis results, data science portfolios, project documentation, and more.
 
 Common Operations:
 


### PR DESCRIPTION
## Corrected a grammatical error in the GitHub Pages description. 

Changes: 
~~directly into a whenever you push it~~  
**directly into a static website whenever you push it**

Instructors, and TAs (@22f3001919 @jkmpod @Jivraj-18 @rohitxiitm), The above changes also have to be done in the [Graded Assignment 2](https://exam.sanand.workers.dev/tds-2025-05-ga2) page as well, hence do change there too.

>*Thanks for your attention to this matter*
~ *Prasanna*.