### PR TITLE
Fix grading formula: GAA and Final exam weightages

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The course covers the typical data science workflow:
 | [Content][Source]           | Assessment     | Weight |    Release Date | Submission Date |
 | --------------------------- | -------------- | -----: | --------------: | --------------: |
 | [Entrance Exam][EE]         | [**EE**][EE]   |     0% | Wed 07 Jan 2026 | Mon 02 Feb 2026 |
-| Graded Assignment (GA)      | Best 5 of 8    |    20% |                 |                 |
+| Graded Assignment (GA)      | Best 5 of 8    |    10% |                 |                 |
 | [Setup][GA1]                | [**GA1**][GA1] |        | Wed 28 Jan 2026 | Mon 09 Feb 2026 |
 | [Deploy][GA2]               | [**GA2**][GA2] |        | Wed 04 Feb 2026 | Mon 16 Feb 2026 |
 | [Source][GA3]               | [**GA3**][GA3] |        | Wed 18 Feb 2026 | Mon 02 Mar 2026 |
@@ -126,7 +126,7 @@ The course covers the typical data science workflow:
 | [Project 1][P1]             | [**P1**][P1]   |    20% |  Fri 6 Feb 2026 | Mon 30 Mar 2026 |
 | [Project 2][P2]             | [**P2**][P2]   |    20% |  Fri 6 Mar 2026 | Mon 13 Apr 2026 |
 | Remote Online Exam ([hard]) | [**ROE**][ROE] |    20% | Sat 28 Mar 2026 | Sat 28 Mar 2026 |
-| Final end-term (in-person)  | F              |    20% | Sun 10 May 2026 | Sun 10 May 2026 |
+| Final end-term (in-person)  | F              |    30% | Sun 10 May 2026 | Sun 10 May 2026 |
 
 [Source]: https://github.com/sanand0/tools-in-data-science-public/commits
 [EE]: https://exam.sanand.workers.dev/tds-2026-01-ee

--- a/marks-dashboard.md
+++ b/marks-dashboard.md
@@ -6,15 +6,15 @@ The final score for the course is calculated as follows:
 
 | Components (All out of 100)              | Weight  |
 |------------------------------------------|---------|
-| Grade Assessments **(GA)** <br> Best 5/8 | 20%     |
+| Grade Assessments **(GA)** <br> Best 5/8 | 10%     |
 | Project 1 **(P1)**                       | 20%     |
 | Project 2 **(P2)**                       | 20%     |
 | Remote Online Exam **(ROE)**             | 20%     |
-| End Term **(ET)**                        | 20%     |
+| End Term **(ET)**                        | 30%     |
 
 #### End Term Eligibility: Best 4/5 first GAs Average >= 40
 
-T = 0.2 GA + 0.2 P1 + 0.2 P2 + 0.2 ROE + 0.2 ET
+T = 0.1 GA + 0.2 P1 + 0.2 P2 + 0.2 ROE + 0.3 ET
 
 > Note: The scores are updated one to two days after the deadline for the GAs and ROEs. Score updates for Projects can take more than a week or two due to large evaluation time frames.
 


### PR DESCRIPTION
The README had incorrect weightages for GAA and Final exam.
Corrected to match the official grading document:
- GAA: 20% → 10%
- Final: 20% → 30%

![Screenshot_20260125_163202_Chrome](https://github.com/user-attachments/assets/850e07cc-fd19-4c83-a433-516fdabe1ee2)

