### PR TITLE
feat: update course schedule for May 2026, enhance menu navigation, and improve sidebar link handling

### DIFF
--- a/2026-01/README.md
+++ b/2026-01/README.md
@@ -132,7 +132,7 @@ The course covers the typical data science workflow:
 | [Package][GA8]              | [**GA8**][GA8] |        | Sun 19 Apr 2026 | Thu 30 Apr 2026 |
 | [Project 1][P1]             | [**P1**][P1]   |    20% | Wed 11 Feb 2026 | Mon 30 Mar 2026 |
 | [Project 2A - picoCTF][P2A] | [**P2A**][P2A] |    20% | Fri 20 Mar 2026 | Mon 27 Apr 2026 |
-| [P2B - New Questions][P2B]  | [**P2B**][P2B] |        | Sun 19 Apr 2026 | Mon 04 May 2026 | 
+| [P2B - New Questions][P2B]  | [**P2B**][P2B] |        | Sun 19 Apr 2026 | Mon 04 May 2026 |
 | Remote Online Exam ([hard]) | [**ROE**][ROE] |    20% | Sun 05 Apr 2026 | Sun 05 Apr 2026 |
 | Final end-term (in-person)  | F              |    20% | Sun 10 May 2026 | Sun 10 May 2026 |
 
@@ -175,11 +175,11 @@ For Project 2: Sign up on [picoCTF](https://play.picoctf.org/) and join the [cla
 | ------------------ | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
 | Faculty            | [Anand S](https://www.linkedin.com/in/sanand0/)                                    | [root.node@gmail.com](mailto:root.node@gmail.com)                       | [@s.anand](https://discourse.onlinedegree.iitm.ac.in/u/s.anand)                   |
 | Instructor         | [Carlton D'Silva](https://www.linkedin.com/in/carlton-d-silva-13770b35a)           | [22f3001919@ds.study.iitm.ac.in](mailto:22f3001919@ds.study.iitm.ac.in) | [@carlton](https://discourse.onlinedegree.iitm.ac.in/u/carlton)                   |
-| Instructor         | [Prasanna S](https://www.linkedin.com/in/prasanna-sugumaran-ab980222/)             | [prasanna@study.iitm.ac.in](mailto:prasanna@study.iitm.ac.in)           | [@iamprasna](https://discourse.onlinedegree.iitm.ac.in/u/iamprasna)                 |
-| Teaching Assistant | [Hritik Roshan Maurya](https://www.linkedin.com/in/hritik-roshan-maurya-28446411a) | [22f3002460@ds.study.iitm.ac.in](mailto:22f3002460@ds.study.iitm.ac.in) | [@HritikRoshan_HRM](https://discourse.onlinedegree.iitm.ac.in/u/hritikroshan_hrm)          |
-| Teaching Assistant | [Jivraj Singh](https://www.linkedin.com/in/jivraj-singh-shekhawat-92a547269/)      | [22f3002542@ds.study.iitm.ac.in](mailto:22f3002542@ds.study.iitm.ac.in) | [@Jivraj](https://discourse.onlinedegree.iitm.ac.in/u/jivraj)                    |
-| Teaching Assistant | [Mayank Poddar](https://www.linkedin.com/in/mynkpdr)                               | [23f3004197@ds.study.iitm.ac.in](mailto:23f3004197@ds.study.iitm.ac.in) | [@23f3004197](https://discourse.onlinedegree.iitm.ac.in/u/23f3004197)                |
-| Teaching Assistant | [Sujal Pradhan](https://www.linkedin.com/in/sujal-raj-pradhan-a85043242/)          | [23f2004759@ds.study.iitm.ac.in](mailto:23f2004759@ds.study.iitm.ac.in) | [@23f2004759](https://discourse.onlinedegree.iitm.ac.in/u/23f2004759)                |
+| Instructor         | [Prasanna S](https://www.linkedin.com/in/prasanna-sugumaran-ab980222/)             | [prasanna@study.iitm.ac.in](mailto:prasanna@study.iitm.ac.in)           | [@iamprasna](https://discourse.onlinedegree.iitm.ac.in/u/iamprasna)               |
+| Teaching Assistant | [Hritik Roshan Maurya](https://www.linkedin.com/in/hritik-roshan-maurya-28446411a) | [22f3002460@ds.study.iitm.ac.in](mailto:22f3002460@ds.study.iitm.ac.in) | [@HritikRoshan_HRM](https://discourse.onlinedegree.iitm.ac.in/u/hritikroshan_hrm) |
+| Teaching Assistant | [Jivraj Singh](https://www.linkedin.com/in/jivraj-singh-shekhawat-92a547269/)      | [22f3002542@ds.study.iitm.ac.in](mailto:22f3002542@ds.study.iitm.ac.in) | [@Jivraj](https://discourse.onlinedegree.iitm.ac.in/u/jivraj)                     |
+| Teaching Assistant | [Mayank Poddar](https://www.linkedin.com/in/mynkpdr)                               | [23f3004197@ds.study.iitm.ac.in](mailto:23f3004197@ds.study.iitm.ac.in) | [@23f3004197](https://discourse.onlinedegree.iitm.ac.in/u/23f3004197)             |
+| Teaching Assistant | [Sujal Pradhan](https://www.linkedin.com/in/sujal-raj-pradhan-a85043242/)          | [23f2004759@ds.study.iitm.ac.in](mailto:23f2004759@ds.study.iitm.ac.in) | [@23f2004759](https://discourse.onlinedegree.iitm.ac.in/u/23f2004759)             |
 
 What to contact whom, for what, and how:
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Tools in Data Science - Jan 2026
+# Tools in Data Science - May 2026
 
 [Tools in Data Science](https://study.iitm.ac.in/ds/course_pages/BSSE2002.html) is a diploma level data science course at IIT Madras.
 
-**It bridges the gap between theory and real-world implementation**. Specifically: you'll learn what tools do data scientists actually use and how.
+**It bridges the gap between theory and real-world implementation**. Specifically: you'll learn what tools data scientists actually use and how.
 
-**It prepares you for AI**. AI is rapidly changing how data science work. You'll practice using AI to learn, execute, and explain data science tasks.
+**It prepares you for AI**. AI is rapidly changing how data science works. You'll practice using AI to learn, execute, and explain data science tasks.
 
 **AI will teach you**. We give you challenges. You learn by yourself, using AI & humans. **Self-learning is part of the course skills**.
 
@@ -17,11 +17,7 @@
 <!-- https://gemini.google.com/app/2421e54562afb8c7 -->
 <!-- Archive: https://gemini.google.com/app/8118aff285667319 -->
 
-**There is no course content**. Just challenges for you to solve, and prompts to guide you.
-
-![](images/there-is-no-content.webp "You learn by solving problems, not by watching videos or reading tutorials.")
-
-<!-- https://gemini.google.com/app/7354ff9f8d18b9c0 -->
+**Course content is there but we highly encourage you to take that as just topic reference and you should do a lot of practice and learn using open internet / AI etc.**
 
 <details>
 <summary><strong>Anyone can audit this course. It's public.</strong></summary>
@@ -44,7 +40,7 @@ Take the [Entrance Exam][EE]. IITM BS students scoring below 40% shouldn't regis
 </details>
 
 <details>
-<summary><strong>It's a practical course. Just get it done. "How" matter less.</strong></summary>
+<summary><strong>It's a practical course. Just get it done. "How" matters less.</strong></summary>
 
 The course models **real-life**. Unclear problems, messy data, ridiculous deadlines, limited support.
 
@@ -81,7 +77,7 @@ Here's students' feedback from past terms:
   [#](https://discourse.onlinedegree.iitm.ac.in/t/is-it-fair-to-consider-20-weightage-of-such-exam-which-is-impossible-to-solve-in-given-time-i-e-roe/141413/10)
 - [Should you take Tools in Data Science this term?](https://discourse.onlinedegree.iitm.ac.in/t/tools-in-data-science-should-you-take-tools-in-data-science-this-term/186454) (Ans: take it in your **last term**)
 
-**[Take Graded assignment 1](https://exam.sanand.workers.dev/tds-2025-09-ga1) to check if you're ready for this course.** Please drop this course (do it in a later term) if you score low. It'll be too tough for you now.
+**[Take Graded assignment 0](https://exam.sanand.workers.dev/tds-2026-05-ga0) to check if you're ready for this course.** Please drop this course (do it in a later term) if you score low. It'll be too tough for you now.
 
 But the learnings may be worth the effort.
 
@@ -118,40 +114,37 @@ Check [system-requirements.md](system-requirements.md) for permissions you need,
 
 The course covers the typical data science workflow:
 
-| [Content][Source]           | Assessment     | Weight |    Release Date | Submission Date |
-| --------------------------- | -------------- | -----: | --------------: | --------------: |
-| [Entrance Exam][EE]         | [**EE**][EE]   |     0% | Wed 07 Jan 2026 | Mon 02 Feb 2026 |
-| Graded Assignment (GA)      | Best 5 of 8    |    20% |                 |                 |
-| [Setup][GA1]                | [**GA1**][GA1] |        | Fri 06 Feb 2026 | Wed 18 Feb 2026 |
-| [Deploy][GA2]               | [**GA2**][GA2] |        | Fri 13 Feb 2026 | Sun 22 Feb 2026 |
-| [Source][GA3]               | [**GA3**][GA3] |        | Fri 20 Feb 2026 | Sun 01 Mar 2026 |
-| [Wrangle][GA4]              | [**GA4**][GA4] |        | Fri 27 Feb 2026 | Sun 08 Mar 2026 |
-| [Analyze][GA5]              | [**GA5**][GA5] |        | Fri 06 Mar 2026 | Fri 20 Mar 2026 |
-| [Test][GA6]                 | [**GA6**][GA6] |        | Sun 22 Mar 2026 | Tue 31 Mar 2026 |
-| [Present][GA7]              | [**GA7**][GA7] |        | Fri 27 Mar 2026 | Mon 13 Apr 2026 |
-| [Package][GA8]              | [**GA8**][GA8] |        | Sun 19 Apr 2026 | Thu 30 Apr 2026 |
-| [Project 1][P1]             | [**P1**][P1]   |    20% | Wed 11 Feb 2026 | Mon 30 Mar 2026 |
-| [Project 2A - picoCTF][P2A] | [**P2A**][P2A] |    20% | Fri 20 Mar 2026 | Mon 27 Apr 2026 |
-| [P2B - New Questions][P2B]  | [**P2B**][P2B] |        | Sun 19 Apr 2026 | Mon 04 May 2026 | 
-| Remote Online Exam ([hard]) | [**ROE**][ROE] |    20% | Sun 05 Apr 2026 | Sun 05 Apr 2026 |
-| Final end-term (in-person)  | F              |    20% | Sun 10 May 2026 | Sun 10 May 2026 |
+| Content                     | Assessment      | Weight | Release Date    | Submission Date | Feedback |
+| --------------------------- | --------------- | -----: | --------------- | --------------- | -------- |
+| Graded Assignment (GA)      | Best 7 of 9     |    20% |                 |                 |          |
+| [Bootcamp][GA0]             | [**GA0**][GA0]  | —      | Thu 14 May 2026 | Sun 21 Jun 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-bootcamp)         |
+| [Week-1][GA1]               | [**GA1**][GA1]  | —      | Wed 17 Jun 2026 | Sun 28 Jun 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-week1-feedback)   |
+| [Week-2][GA2]               | [**GA2**][GA2]  | —      | Wed 24 Jun 2026 | Sun 05 Jul 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-week2-feedback)   |
+| [Project 1][P1]             | **P1**          |    20% | Wed 24 Jun 2026 | Wed 22 Jul 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-project1-feedback)|
+| [Week-3][GA3]               | [**GA3**][GA3]  | —      | Wed 01 Jul 2026 | Sun 12 Jul 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-week3-feedback)   |
+| [Week-4][GA4]               | [**GA4**][GA4]  | —      | Wed 08 Jul 2026 | Wed 22 Jul 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-week4-feedback)   |
+| [Week-5][GA5]               | [**GA5**][GA5]  | —      | Wed 15 Jul 2026 | Sun 26 Jul 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-week5-feedback)   |
+| [Week-6][GA6]               | [**GA6**][GA6]  | —      | Wed 22 Jul 2026 | Sun 02 Aug 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-week6-feedback)   |
+| [Project 2][P2]             | **P2**          |    20% | Wed 22 Jul 2026 | Wed 19 Aug 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-project2-feedback)|
+| [Remote Online Exam][ROE]   | [**ROE**][ROE]  |    20% | Sun 02 Aug 2026 | Sun 02 Aug 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-roe-feedback)     |
+| [Week-7][GA7]               | [**GA7**][GA7]  | —      | Wed 05 Aug 2026 | Wed 19 Aug 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-week7-feedback)   |
+| [Week-8][GA8]               | [**GA8**][GA8]  | —      | Wed 12 Aug 2026 | Sun 23 Aug 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-week8-feedback)   |
+| Final end-term (in-person)  | F               |    20% | Sun 13 Sep 2026 | Sun 13 Sep 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-et)               |
 
-For Project 2: Sign up on [picoCTF](https://play.picoctf.org/) and join the [classroom](https://play.picoctf.org/classrooms) with invite code: `CTuhJLfpM`. Then solve your [assigned questions](https://play.picoctf.org/practice?assigned=1). **You must complete both parts of P2** (picoCTF AND New Questions) for the full P2 score.
 
 [Source]: https://github.com/sanand0/tools-in-data-science-public/commits
-[EE]: https://exam.sanand.workers.dev/tds-2026-01-ee
-[GA1]: https://exam.sanand.workers.dev/tds-2026-01-ga1
-[GA2]: https://exam.sanand.workers.dev/tds-2026-01-ga2
-[GA3]: https://exam.sanand.workers.dev/tds-2026-01-ga3
-[GA4]: https://exam.sanand.workers.dev/tds-2026-01-ga4
-[GA5]: https://exam.sanand.workers.dev/tds-2026-01-ga5
-[GA6]: https://exam.sanand.workers.dev/tds-2026-01-ga6
-[GA7]: https://exam.sanand.workers.dev/tds-2026-01-ga7
-[GA8]: https://exam.sanand.workers.dev/tds-2026-01-ga8
-[P1]: https://exam.sanand.workers.dev/tds-2026-01-p1
-[P2A]: https://play.picoctf.org/
-[P2B]: https://exam.sanand.workers.dev/tds-2026-01-p2
-[ROE]: https://exam.sanand.workers.dev/tds-2026-01-roe
+[GA0]: https://exam.sanand.workers.dev/tds-2026-05-ga0
+[GA1]: https://exam.sanand.workers.dev/tds-2026-05-ga1
+[GA2]: https://exam.sanand.workers.dev/tds-2026-05-ga2
+[GA3]: https://exam.sanand.workers.dev/tds-2026-05-ga3
+[GA4]: https://exam.sanand.workers.dev/tds-2026-05-ga4
+[GA5]: https://exam.sanand.workers.dev/tds-2026-05-ga5
+[GA6]: https://exam.sanand.workers.dev/tds-2026-05-ga6
+[GA7]: https://exam.sanand.workers.dev/tds-2026-05-ga7
+[GA8]: https://exam.sanand.workers.dev/tds-2026-05-ga8
+[P1]: https://exam.sanand.workers.dev/tds-2026-05-p1
+[P2]: https://exam.sanand.workers.dev/tds-2026-05-p2
+[ROE]: https://exam.sanand.workers.dev/tds-2026-05-roe
 [hard]: https://discourse.onlinedegree.iitm.ac.in/t/roe-prep-discussion-thread-tds-may-2025/181581/25
 
 **Notes**
@@ -160,14 +153,14 @@ For Project 2: Sign up on [picoCTF](https://play.picoctf.org/) and join the [cla
 
 ## Resources
 
-| Resource                      | IITM                                                                                                                                        | Public                                                                        |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| Live Video Sessions           | [Recordings](https://drive.google.com/drive/folders/1smwtcdgiANDkrs8LhnGGAEr43Yhp-R9O)                                                      | [YouTube](https://www.youtube.com/@se-lr5ff) / [Archives](live-sessions.md)   |
-| Discussion                    | [IITM](https://discourse.onlinedegree.iitm.ac.in/c/courses/tds-kb/34)                                                                       | [Public](https://github.com/sanand0/tools-in-data-science-public/discussions) |
-| Course page - Jan 2026        | [IITM](https://seek.onlinedegree.iitm.ac.in/courses/ns_26t1_se2002)                                                                         | [Public](https://tds.s-anand.net/)                                            |
-| Announcement group - Jan 2026 | [IITM](https://groups.google.com/a/study.iitm.ac.in/g/26t1_se2002-announce)                                                                 | [Public](https://groups.google.com/g/tds-iitm)                                |
-| Grading Document - Jan 2026   | [IITM](https://docs.google.com/document/d/e/2PACX-1vSUvKzH7yIXNVwUgRYSIT8M0x1jhFSkslEtj9UPo3dtWI_sJ38Hh_PzbBygpF0vIOo8K7lTy-uYkqdu/pub)     |                                                                               |
-| Student Handbook              | [IITM](https://docs.google.com/document/u/2/d/e/2PACX-1vRxGnnDCVAO3KX2CGtMIcJQuDrAasVk2JHbDxkjsGrTP5ShhZK8N6ZSPX89lexKx86QPAUswSzGLsOA/pub) |                                                                               |
+| Resource                      | IITM                                                                                                                                                                  | Public                                                                        |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Live Video Sessions           |                                                                                                                                                                       | [YouTube](https://www.youtube.com/@se-lr5ff) / [Archives](live-sessions.md)   |
+| Discussion                    | [IITM](https://discourse.onlinedegree.iitm.ac.in/c/courses/tds-kb/34)                                                                                                 | [Public](https://github.com/sanand0/tools-in-data-science-public/discussions) |
+| Course page - May 2026        | [IITM](https://seek.onlinedegree.iitm.ac.in/courses/ns_26t2_se2002)                                                                                                   | [Public](https://tds.s-anand.net/)                                            |
+| Announcement group - May 2026 | [IITM](https://groups.google.com/a/study.iitm.ac.in/g/26t2_se2002-announce)                                                                                           | [Public](https://groups.google.com/g/tds-iitm)                                |
+| Grading Document - May 2026   | [IITM](https://docs.google.com/document/d/e/2PACX-1vT5PBOz4OH663W0IJPVGVjG_nfmYZGfFI7W1j-6wTLcex13O_7BZmf6a96Q6liO0W-mLZB5hOGZeNNl/pub#h.2bn6wsx)                     |                                                                               |
+| Student Handbook              | [IITM](https://docs.google.com/document/d/e/2PACX-1vRxGnnDCVAO3KX2CGtMIcJQuDrAasVk2JHbDxkjsGrTP5ShhZK8N6ZSPX89lexKx86QPAUswSzGLsOA/pub)                               |                                                                               |
 
 ## Contacts
 
@@ -175,16 +168,16 @@ For Project 2: Sign up on [picoCTF](https://play.picoctf.org/) and join the [cla
 | ------------------ | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
 | Faculty            | [Anand S](https://www.linkedin.com/in/sanand0/)                                    | [root.node@gmail.com](mailto:root.node@gmail.com)                       | [@s.anand](https://discourse.onlinedegree.iitm.ac.in/u/s.anand)                   |
 | Instructor         | [Carlton D'Silva](https://www.linkedin.com/in/carlton-d-silva-13770b35a)           | [22f3001919@ds.study.iitm.ac.in](mailto:22f3001919@ds.study.iitm.ac.in) | [@carlton](https://discourse.onlinedegree.iitm.ac.in/u/carlton)                   |
-| Instructor         | [Prasanna S](https://www.linkedin.com/in/prasanna-sugumaran-ab980222/)             | [prasanna@study.iitm.ac.in](mailto:prasanna@study.iitm.ac.in)           | [@iamprasna](https://discourse.onlinedegree.iitm.ac.in/u/iamprasna)                 |
-| Teaching Assistant | [Hritik Roshan Maurya](https://www.linkedin.com/in/hritik-roshan-maurya-28446411a) | [22f3002460@ds.study.iitm.ac.in](mailto:22f3002460@ds.study.iitm.ac.in) | [@HritikRoshan_HRM](https://discourse.onlinedegree.iitm.ac.in/u/hritikroshan_hrm)          |
-| Teaching Assistant | [Jivraj Singh](https://www.linkedin.com/in/jivraj-singh-shekhawat-92a547269/)      | [22f3002542@ds.study.iitm.ac.in](mailto:22f3002542@ds.study.iitm.ac.in) | [@Jivraj](https://discourse.onlinedegree.iitm.ac.in/u/jivraj)                    |
-| Teaching Assistant | [Mayank Poddar](https://www.linkedin.com/in/mynkpdr)                               | [23f3004197@ds.study.iitm.ac.in](mailto:23f3004197@ds.study.iitm.ac.in) | [@23f3004197](https://discourse.onlinedegree.iitm.ac.in/u/23f3004197)                |
-| Teaching Assistant | [Sujal Pradhan](https://www.linkedin.com/in/sujal-raj-pradhan-a85043242/)          | [23f2004759@ds.study.iitm.ac.in](mailto:23f2004759@ds.study.iitm.ac.in) | [@23f2004759](https://discourse.onlinedegree.iitm.ac.in/u/23f2004759)                |
+| Instructor         | [Prasanna S](https://www.linkedin.com/in/prasanna-sugumaran-ab980222/)             | [prasanna@study.iitm.ac.in](mailto:prasanna@study.iitm.ac.in)           | [@iamprasna](https://discourse.onlinedegree.iitm.ac.in/u/iamprasna)               |
+| Teaching Assistant | [Hritik Roshan Maurya](https://www.linkedin.com/in/hritik-roshan-maurya-28446411a) | [22f3002460@ds.study.iitm.ac.in](mailto:22f3002460@ds.study.iitm.ac.in) | [@HritikRoshan_HRM](https://discourse.onlinedegree.iitm.ac.in/u/hritikroshan_hrm) |
+| Teaching Assistant | [Mayank Poddar](https://www.linkedin.com/in/mynkpdr)                               | [23f3004197@ds.study.iitm.ac.in](mailto:23f3004197@ds.study.iitm.ac.in) | [@23f3004197](https://discourse.onlinedegree.iitm.ac.in/u/23f3004197)             |
+| Teaching Assistant | [Jaideep Medavarapu](https://discourse.onlinedegree.iitm.ac.in/u/jaideep)          | [23f2001992@ds.study.iitm.ac.in](mailto:23f2001992@ds.study.iitm.ac.in) | [@jaideep](https://discourse.onlinedegree.iitm.ac.in/u/jaideep)                   |
+| Teaching Assistant | [Agrim Srivastava](https://discourse.onlinedegree.iitm.ac.in/u/23f3002782)         | [23f3002782@ds.study.iitm.ac.in](mailto:23f3002782@ds.study.iitm.ac.in) | [@23f3002782](https://discourse.onlinedegree.iitm.ac.in/u/23f3002782)             |
 
 What to contact whom, for what, and how:
 
 - **Teaching assistants**: To learn the subject **after** asking AI twice. E.g. "How do I solve this assignment / project"
-- **Unstructors**: For exceptions **after** asking AI, TAs, and with proof. E.g. "My marks are wrong", "I need an extension", etc.
+- **Instructors**: For exceptions **after** asking AI, TAs, and with proof. E.g. "My marks are wrong", "I need an extension", etc.
 - **Faculty**: For suggestions on next term's course content.
 
 We used to have a [Virtual TA](https://chatgpt.com/g/g-mZqKVxKDx-iitm-tds-teaching-assistant) (a [custom GPT](tds-ta-instructions.md)) who has retired now.
@@ -195,12 +188,12 @@ Check these three links regularly to keep up with the course.
 
 1. **[Seek Notifications](https://seek.onlinedegree.iitm.ac.in/)** for Course Notifications. Log into [seek.onlinedegree.iitm.ac.in](https://seek.onlinedegree.iitm.ac.in/) and click on the bell icon on the top right corner. Check notifications daily.
    ![Portal Inbox](images/portal_notifications.webp)
-2. **[Your email](https://mail.google.com/)** for Course Announcements. [Seek](https://seek.onlinedegree.iitm.ac.in/) Inbox are forwarded to your email. Check daily. Check spam folders too.
+2. **[Your email](https://mail.google.com/)** for Course Announcements. [Seek](https://seek.onlinedegree.iitm.ac.in/) Inbox is forwarded to your email. Check daily. Check spam folders too.
 3. **[TDS Discourse](https://discourse.onlinedegree.iitm.ac.in/c/courses/tds-kb/34)**: Faculty, instructors, and TAs will share updates and address queries here. Email [support@study.iitm.ac.in](mailto:support@study.iitm.ac.in) cc: [discourse-staff1@study.iitm.ac.in](mailto:discourse-staff1@study.iitm.ac.in) if you can't access Discourse.
 
 ## Previous terms
 
+- No Content for Jan 2026 Term
 - [TDS: Course Content - Sep 2025](2025-09/)
 - [TDS: Course Content - May 2025](2025-05/)
-  - [Community solutions](https://tdsfu.pages.dev/)
 - [TDS: Course Content - Jan 2025](2025-01/)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 <!-- https://gemini.google.com/app/2421e54562afb8c7 -->
 <!-- Archive: https://gemini.google.com/app/8118aff285667319 -->
 
-**Course content is there but we highly encourage you to take that as just topic reference and you should do a lot of practice and learn using open internet / AI etc.**
+ **Course content is available, but treat it only as a topic reference — practice extensively and learn using the open internet and AI.**
 
 <details>
 <summary><strong>Anyone can audit this course. It's public.</strong></summary>
@@ -35,7 +35,7 @@ Enrolled [IITM students](https://study.iitm.ac.in/ds/) can additionally particip
 
 You need a _good_ understanding of Python, JavaScript, HTML, APIs, Excel, ChatGPT, and data science concepts.
 
-Take the [Entrance Exam][EE]. IITM BS students scoring below 40% shouldn't register for this course (unless there's no choice).
+Take the [Entrance Exam][GA0]. IITM BS students scoring below 40% shouldn't register for this course (unless there's no choice).
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -118,18 +118,18 @@ The course covers the typical data science workflow:
 | --------------------------- | --------------- | -----: | --------------- | --------------- | -------- |
 | Graded Assignment (GA)      | Best 7 of 9     |    20% |                 |                 |          |
 | [Bootcamp][GA0]             | [**GA0**][GA0]  | —      | Thu 14 May 2026 | Sun 21 Jun 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-bootcamp)         |
-| [Week-1][GA1]               | [**GA1**][GA1]  | —      | Wed 17 Jun 2026 | Sun 28 Jun 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-week1-feedback)   |
-| [Week-2][GA2]               | [**GA2**][GA2]  | —      | Wed 24 Jun 2026 | Sun 05 Jul 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-week2-feedback)   |
-| [Project 1][P1]             | **P1**          |    20% | Wed 24 Jun 2026 | Wed 22 Jul 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-project1-feedback)|
-| [Week-3][GA3]               | [**GA3**][GA3]  | —      | Wed 01 Jul 2026 | Sun 12 Jul 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-week3-feedback)   |
-| [Week-4][GA4]               | [**GA4**][GA4]  | —      | Wed 08 Jul 2026 | Wed 22 Jul 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-week4-feedback)   |
-| [Week-5][GA5]               | [**GA5**][GA5]  | —      | Wed 15 Jul 2026 | Sun 26 Jul 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-week5-feedback)   |
-| [Week-6][GA6]               | [**GA6**][GA6]  | —      | Wed 22 Jul 2026 | Sun 02 Aug 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-week6-feedback)   |
-| [Project 2][P2]             | **P2**          |    20% | Wed 22 Jul 2026 | Wed 19 Aug 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-project2-feedback)|
-| [Remote Online Exam][ROE]   | [**ROE**][ROE]  |    20% | Sun 02 Aug 2026 | Sun 02 Aug 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-roe-feedback)     |
-| [Week-7][GA7]               | [**GA7**][GA7]  | —      | Wed 05 Aug 2026 | Wed 19 Aug 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-week7-feedback)   |
-| [Week-8][GA8]               | [**GA8**][GA8]  | —      | Wed 12 Aug 2026 | Sun 23 Aug 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-week8-feedback)   |
-| Final end-term (in-person)  | F               |    20% | Sun 13 Sep 2026 | Sun 13 Sep 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-et)               |
+| [Week-1][GA1]               | [**GA1**][GA1]  | —      | Wed 17 Jun 2026 | Sun 28 Jun 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-feedback#week1)   |
+| [Week-2][GA2]               | [**GA2**][GA2]  | —      | Wed 24 Jun 2026 | Sun 05 Jul 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-feedback#week2)   |
+| [Project 1][P1]             | **P1**          |    20% | Wed 24 Jun 2026 | Wed 22 Jul 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-feedback#project1)|
+| [Week-3][GA3]               | [**GA3**][GA3]  | —      | Wed 01 Jul 2026 | Sun 12 Jul 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-feedback#week3)   |
+| [Week-4][GA4]               | [**GA4**][GA4]  | —      | Wed 08 Jul 2026 | Wed 22 Jul 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-feedback#week4)   |
+| [Week-5][GA5]               | [**GA5**][GA5]  | —      | Wed 15 Jul 2026 | Sun 26 Jul 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-feedback#week5)   |
+| [Week-6][GA6]               | [**GA6**][GA6]  | —      | Wed 22 Jul 2026 | Sun 02 Aug 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-feedback#week6)   |
+| [Project 2][P2]             | **P2**          |    20% | Wed 22 Jul 2026 | Wed 19 Aug 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-feedback#project2)|
+| [Remote Online Exam][ROE]   | [**ROE**][ROE]  |    20% | Sun 02 Aug 2026 (01:00 PM) | Sun 02 Aug 2026 (01:45 PM) | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-feedback#roe)     |
+| [Week-7][GA7]               | [**GA7**][GA7]  | —      | Wed 05 Aug 2026 | Wed 19 Aug 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-feedback#week7)   |
+| [Week-8][GA8]               | [**GA8**][GA8]  | —      | Wed 12 Aug 2026 | Sun 23 Aug 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-feedback#week8)   |
+| Final end-term (in-person)  | F               |    20% | Sun 13 Sep 2026 | Sun 13 Sep 2026 | [Feedback](https://exam.sanand.workers.dev/tds-2026-05-feedback#endterm) |
 
 
 [Source]: https://github.com/sanand0/tools-in-data-science-public/commits

--- a/_sidebar.md
+++ b/_sidebar.md
@@ -1,173 +1,259 @@
 - [May 2026: Tools in Data Science](/)
-- [Marks Dashboard](marks-dashboard.md)
+
+<div class="tds-link">
+
+[Marks Dashboard](marks-dashboard.md)
+
+</div>
 
 ---
 
-- **0. Bridge Course**
-  - [📋 Syllabus](2026-02/docs/bridge-course/bridge-course-syllabus.md)
-  - **Day 1 — Setup Day**
-    - [Installation](2026-02/docs/bridge-course/day-1-installation.md)
-    - [File Structure (Windows vs Linux)](2026-02/docs/bridge-course/day-1-file-structure.md)
-    - [Path Reading](2026-02/docs/bridge-course/day-1-path-reading.md)
-    - [Quiz & Exercises](2026-02/docs/bridge-course/day-1-quiz-exercises.md)
-  - **Day 2 — Linux & Shell Essentials**
-    - [Terminal Navigation](2026-02/docs/bridge-course/day-2-terminal-navigation.md)
-    - [touch, mkdir, rm, cp, mv](2026-02/docs/bridge-course/day-2-touch-mkdir-rm-cp-mv.md)
-    - [Basic Script Writing](2026-02/docs/bridge-course/day-2-basic-script-writing.md)
-    - [Quiz & Exercises](2026-02/docs/bridge-course/day-2-quiz-exercises.md)
-  - **Day 3 — VS Code + Python Project Setup with UV**
-    - [VS Code Setup](2026-02/docs/bridge-course/day-3-vscode-setup.md)
-    - [Virtual Environments](2026-02/docs/bridge-course/day-3-virtual-environments.md)
-    - [UV Workflow](2026-02/docs/bridge-course/day-3-uv-workflow.md)
-    - [Quiz & Exercises](2026-02/docs/bridge-course/day-3-quiz-exercises.md)
-  - **Day 4 — HTTP, APIs, Chrome DevTools**
-    - [HTTP Fundamentals](2026-02/docs/bridge-course/day-4-http-fundamentals.md)
-    - [Chrome DevTools](2026-02/docs/bridge-course/day-4-chrome-devtools.md)
-    - [API Testing with curl](2026-02/docs/bridge-course/day-4-api-testing-curl.md)
-    - [Quiz & Exercises](2026-02/docs/bridge-course/day-4-quiz-exercises.md)
-  - **Day 5 — Git & GitHub Workflow**
-    - [Git Basic Flow](2026-02/docs/bridge-course/day-5-git-basic-flow.md)
-    - [Init, Add, Commit](2026-02/docs/bridge-course/day-5-init-add-commit.md)
-    - [GitHub SSH Login](2026-02/docs/bridge-course/day-5-github-ssh-login.md)
-    - [Quiz & Exercises](2026-02/docs/bridge-course/day-5-quiz-exercises.md)
+<details class="tds-week">
+<summary>Week 0: Bridge Course</summary>
 
-- **1. Dev Environment & Tooling**
-  - [VS Code](2026-02/docs/week-1/01-vscode.md)
-  - [UV — Python Package Manager](2026-02/docs/week-1/02-uv.md)
-  - [Bash Scripting](2026-02/docs/week-1/03-bash-scripting.md)
-  - [Git & GitHub](2026-02/docs/week-1/04-git-github.md)
-  - [SQLite](2026-02/docs/week-1/05-sqlite.md)
-  - [HTTP Clients](2026-02/docs/week-1/06-http-clients.md)
-  - [Requestly](2026-02/docs/week-1/07-requestly.md)
-  - [Data Formats](2026-02/docs/week-1/08-data-formats.md)
-  - [GitHub Pages](2026-02/docs/week-1/09-github-pages.md)
-  - [LaTeX](2026-02/docs/week-1/10-latex.md)
-  - [**Lab: Publish a Python library to PyPI**](2026-02/docs/labs/week-1/01-publish-python-library-pypi-uv.md)
-  - [**Lab: Publish a UV CLI tool**](2026-02/docs/labs/week-1/02-uv-cli-tool-latex-docs.md)
-  - [**Lab: Bash automation**](2026-02/docs/labs/week-1/03-bash-daily-project-summary.md)
+- [📋 Syllabus](2026-02/docs/bridge-course/bridge-course-syllabus.md)
 
-- **2. Deployment & API Engineering**
-  - [FastAPI Fundamentals](2026-02/docs/week-2/01-fastapi.md)
-  - [CORS & Middleware](2026-02/docs/week-2/02-cors-middleware.md)
-  - [Google OAuth 2.0](2026-02/docs/week-2/03-google-oauth.md)
-  - [FastAPI Advanced](2026-02/docs/week-2/04-fastapi-advanced.md)
-  - [Config Management](2026-02/docs/week-2/05-config-management.md)
-  - [Docker & Compose](2026-02/docs/week-2/06-docker-compose.md)
-  - [Deployment Platforms](2026-02/docs/week-2/07-deployment-platforms.md)
-  - [Logging & Testing](2026-02/docs/week-2/08-logging-testing.md)
-  - [Observability](2026-02/docs/week-2/09-observability.md)
-  - [Cloudflare Tunnels](2026-02/docs/week-2/10-cloudflare-tunnels.md)
-  - [Local LLMs](2026-02/docs/week-2/11-local-llms.md)
-  - [Redis Caching](2026-02/docs/week-2/12-redis-caching.md)
-  - [**Lab: Publish a Gemma model API**](2026-02/docs/labs/week-2/gemma-api-hf-spaces-google-auth.md)
-  - [**Lab: Add full observability**](2026-02/docs/labs/week-2/fastapi-observability-grafana.md)
+**Day 1 — Setup Day**
+- [Installation](2026-02/docs/bridge-course/day-1-installation.md)
+- [File Structure (Windows vs Linux)](2026-02/docs/bridge-course/day-1-file-structure.md)
+- [Path Reading](2026-02/docs/bridge-course/day-1-path-reading.md)
+- [Quiz & Exercises](2026-02/docs/bridge-course/day-1-quiz-exercises.md)
 
-- **3. LLM Engineering**
-  - [Prompt Engineering](2026-02/docs/week-3/prompt-engineering.md)
-  - [Context Engineering](2026-02/docs/week-3/context-engineering.md)
-  - [Prompt Caching](2026-02/docs/week-3/prompt-caching.md)
-  - [Structured Output](2026-02/docs/week-3/structured-output.md)
-  - [LLM Architecture Survey](2026-02/docs/week-3/llm-architecture-survey.md)
-  - [Multimodal Inputs](2026-02/docs/week-3/multimodal-inputs.md)
-  - [Vector Embeddings](2026-02/docs/week-3/vector-embeddings.md)
-  - [Similarity Search](2026-02/docs/week-3/similarity-search.md)
-  - [LLM CLI Tools](2026-02/docs/week-3/llm-cli-tools.md)
-  - [AI Coding Assistants](2026-02/docs/week-3/ai-coding-assistants.md)
-  - [LangSmith & LiteLLM](2026-02/docs/week-3/langsmith-litellm.md)
-  - [**Lab: YouTube → Subtitles → Topics pipeline**](2026-02/docs/labs/week-3/youtube-subtitles-topics-json-pipeline.md)
-  - [**Lab: Cost-tracking dashboard**](2026-02/docs/labs/week-3/cost-tracking-dashboard-langsmith.md)
+**Day 2 — Linux & Shell Essentials**
+- [Terminal Navigation](2026-02/docs/bridge-course/day-2-terminal-navigation.md)
+- [touch, mkdir, rm, cp, mv](2026-02/docs/bridge-course/day-2-touch-mkdir-rm-cp-mv.md)
+- [Basic Script Writing](2026-02/docs/bridge-course/day-2-basic-script-writing.md)
+- [Quiz & Exercises](2026-02/docs/bridge-course/day-2-quiz-exercises.md)
 
-- **4. RAG & Hybrid RAG**
-  - [Vector Databases](2026-02/docs/week-4/vector-databases.md)
-  - [Chunking Strategies](2026-02/docs/week-4/chunking-strategies.md)
-  - [Late Chunking](2026-02/docs/week-4/late-chunking.md)
-  - [Contextual Retrieval](2026-02/docs/week-4/contextual-retrieval.md)
-  - [Hybrid Search](2026-02/docs/week-4/hybrid-search.md)
-  - [Reranking](2026-02/docs/week-4/reranking.md)
-  - [Query Augmentation](2026-02/docs/week-4/query-augmentation.md)
-  - [Semantic Caching](2026-02/docs/week-4/semantic-caching.md)
-  - [Multimodal Embeddings](2026-02/docs/week-4/multimodal-embeddings.md)
-  - [GraphRAG](2026-02/docs/week-4/graphrag.md)
-  - [LLM Grounding & Citations](2026-02/docs/week-4/llm-grounding.md)
-  - [RAGAS Evaluation](2026-02/docs/week-4/ragas-evaluation.md)
-  - [**Lab: RAGAS evaluation dashboard**](2026-02/docs/labs/week-4/ragas-evaluation-dashboard.md)
-  - [**CAPSTONE: BS Degree Chatbot**](2026-02/docs/labs/week-4/capstone-bs-degree-chatbot.md)
-  - [**CAPSTONE: Policy Chatbot**](2026-02/docs/labs/week-4/capstone-policy-chatbot.md)
+**Day 3 — VS Code + Python Project Setup with UV**
+- [VS Code Setup](2026-02/docs/bridge-course/day-3-vscode-setup.md)
+- [Virtual Environments](2026-02/docs/bridge-course/day-3-virtual-environments.md)
+- [UV Workflow](2026-02/docs/bridge-course/day-3-uv-workflow.md)
+- [Quiz & Exercises](2026-02/docs/bridge-course/day-3-quiz-exercises.md)
 
-- [Project 1](2026-02/docs/projects/01-project-1.md)
+**Day 4 — HTTP, APIs, Chrome DevTools**
+- [HTTP Fundamentals](2026-02/docs/bridge-course/day-4-http-fundamentals.md)
+- [Chrome DevTools](2026-02/docs/bridge-course/day-4-chrome-devtools.md)
+- [API Testing with curl](2026-02/docs/bridge-course/day-4-api-testing-curl.md)
+- [Quiz & Exercises](2026-02/docs/bridge-course/day-4-quiz-exercises.md)
 
-- **5. Agentic AI**
-  - [Agent Fundamentals](2026-02/docs/week-5/agent-fundamentals.md)
-  - [Tool / Function Calling](2026-02/docs/week-5/tool-calling.md)
-  - [Agent Memory Systems](2026-02/docs/week-5/agent-memory-systems.md)
-  - [LangGraph](2026-02/docs/week-5/langgraph.md)
-  - [Multi-Agent Systems](2026-02/docs/week-5/multi-agent-systems.md)
-  - [Specialized Agents](2026-02/docs/week-5/specialized-agents.md)
-  - [Model Context Protocol (MCP)](2026-02/docs/week-5/mcp.md)
-  - [Custom MCP Servers](2026-02/docs/week-5/custom-mcp-servers.md)
-  - [Async & Parallelism](2026-02/docs/week-5/async-parallelism.md)
-  - [LXD Sandboxing](2026-02/docs/week-5/lxd-sandboxing.md)
-  - [Agent Evaluation](2026-02/docs/week-5/agent-evaluation.md)
-  - [**Lab: Context-based extraction tool**](2026-02/docs/labs/week-5/context-based-extraction-tool.md)
-  - [**CAPSTONE: Autonomous Research Agent**](2026-02/docs/labs/week-5/capstone-autonomous-research-agent.md)
-  - [**CAPSTONE: VivaAgent — AI Oral Examiner**](2026-02/docs/labs/week-5/capstone-vivaagent-oral-examiner.md)
+**Day 5 — Git & GitHub Workflow**
+- [Git Basic Flow](2026-02/docs/bridge-course/day-5-git-basic-flow.md)
+- [Init, Add, Commit](2026-02/docs/bridge-course/day-5-init-add-commit.md)
+- [GitHub SSH Login](2026-02/docs/bridge-course/day-5-github-ssh-login.md)
+- [Quiz & Exercises](2026-02/docs/bridge-course/day-5-quiz-exercises.md)
 
-- **6. Web Scraping & Data Processing**
-  - [Playwright & Selenium](2026-02/docs/week-6/playwright-selenium.md)
-  - [Scrapy](2026-02/docs/week-6/scrapy.md)
-  - [Anti-bot Patterns](2026-02/docs/week-6/anti-bot-patterns.md)
-  - [Crawl4AI](2026-02/docs/week-6/crawl4ai.md)
-  - [Firecrawl & Apify](2026-02/docs/week-6/firecrawl-apify.md)
-  - [Vision Models for Scraping](2026-02/docs/week-6/vision-models-for-scraping.md)
-  - [Document Parsing](2026-02/docs/week-6/document-parsing.md)
-  - [DuckDB + Parquet](2026-02/docs/week-6/duckdb-parquet.md)
-  - [Image Processing Pipeline](2026-02/docs/week-6/image-processing-pipeline.md)
-  - [Speech AI](2026-02/docs/week-6/speech-ai.md)
-  - [Video Understanding](2026-02/docs/week-6/video-understanding.md)
-  - [Firestore Database](2026-02/docs/week-6/firestore.md)
-  - [Scheduled Scraping](2026-02/docs/week-6/scheduled-scraping.md)
-  - [LLM Architecture](2026-02/docs/week-6/llm-architecture.md)
-  - [**Lab: Scheduled scraper with GitHub Actions**](2026-02/docs/labs/week-6/scheduled-scraper-github-actions-cron.md)
-  - [**CAPSTONE: Job Posting Scraper**](2026-02/docs/labs/week-6/capstone-job-posting-scraper-tracker.md)
-  - [**CAPSTONE: AI Signature Detection**](2026-02/docs/labs/week-6/capstone-ai-signature-detection-cropper.md)
-  - [**CAPSTONE: Live Multilingual Translator**](2026-02/docs/labs/week-6/capstone-live-multilingual-travel-translator.md)
+</details>
 
-- **7. CI/CD, Security & Cloud**
-  - [GitHub Actions Advanced](2026-02/docs/week-7/01-github-actions-advanced.md)
-  - [Advanced Docker](2026-02/docs/week-7/02-advanced-docker.md)
-  - [Serverless Functions](2026-02/docs/week-7/07-serverless-functions.md)
-  - [LLM Security — Offensive](2026-02/docs/week-7/03-llm-security-offensive.md)
-  - [LLM Safety — Defensive](2026-02/docs/week-7/04-llm-safety-defensive.md)
-  - [OWASP LLM Top 10](2026-02/docs/week-7/05-owasp-llm-top-10.md)
-  - [VMs & SSH](2026-02/docs/week-7/06-vms-ssh.md)
-  - [Terraform & IaC](2026-02/docs/week-7/08-terraform-iac.md)
-  - [Cost Alerting & Budgets](2026-02/docs/week-7/09-cost-alerting.md)
-  - [Pub/Sub & Event-Driven](2026-02/docs/week-7/10-pubsub-event-driven.md)
-  - [**Lab: Red-team your own API**](2026-02/docs/labs/week-7/01-red-team-your-api-guardrails.md)
-  - [**Lab: Full CI/CD to Cloud Run**](2026-02/docs/labs/week-7/02-full-cicd-cloud-run.md)
+<details class="tds-week">
+<summary>Week 1: Dev Environment & Tooling</summary>
 
-- **8. MLOps & Fine-Tuning**
-  - [Cloud Storage for ML](2026-02/docs/week-8/01-cloud-storage-ml.md)
-  - [BigQuery ML](2026-02/docs/week-8/02-bigquery-ml.md)
-  - [GCP ML Pipeline](2026-02/docs/week-8/09-gcp-ml-pipeline.md)
-  - [MLflow](2026-02/docs/week-8/03-mlflow.md)
-  - [Fine-Tuning Strategy](2026-02/docs/week-8/04-finetuning-strategy.md)
-  - [HuggingFace Ecosystem](2026-02/docs/week-8/05-huggingface-ecosystem.md)
-  - [Fine-Tuning Techniques](2026-02/docs/week-8/06-finetuning-techniques.md)
-  - [Quantization](2026-02/docs/week-8/07-quantization.md)
-  - [Gemma 4 Fine-Tuning](2026-02/docs/week-8/08-gemma4-finetuning.md)
-  - [Model Publishing & Cards](2026-02/docs/week-8/10-model-publishing.md)
-  - [**Lab: Full GCP pipeline**](2026-02/docs/labs/week-8/02-full-gcp-pipeline-bqml-vertex-cloud-run.md)
-  - [**CAPSTONE: Production Fine-Tuned Model**](2026-02/docs/labs/week-8/01-capstone-production-finetuned-model-mlops.md)
+- [VS Code](2026-02/docs/week-1/01-vscode.md)
+- [UV — Python Package Manager](2026-02/docs/week-1/02-uv.md)
+- [Bash Scripting](2026-02/docs/week-1/03-bash-scripting.md)
+- [Git & GitHub](2026-02/docs/week-1/04-git-github.md)
+- [SQLite](2026-02/docs/week-1/05-sqlite.md)
+- [HTTP Clients](2026-02/docs/week-1/06-http-clients.md)
+- [Requestly](2026-02/docs/week-1/07-requestly.md)
+- [Data Formats](2026-02/docs/week-1/08-data-formats.md)
+- [GitHub Pages](2026-02/docs/week-1/09-github-pages.md)
+- [LaTeX](2026-02/docs/week-1/10-latex.md)
 
-- [Project 2](2026-02/docs/projects/02-project-2.md)
+<div class="tds-link">
 
-- **Reference**
-  - [Tools Glossary](2026-02/docs/reference/01-tools-glossary.md)
-  - [Command Cheatsheet](2026-02/docs/reference/02-command-cheatsheet.md)
-  - [All Lab Assignments](2026-02/docs/labs/all-lab-assignments.md)
-  - [All Capstone Projects](2026-02/docs/labs/capstone-projects.md)
+[Lab: Publish a Python library to PyPI](2026-02/docs/labs/week-1/01-publish-python-library-pypi-uv.md)
+[Lab: Publish a UV CLI tool](2026-02/docs/labs/week-1/02-uv-cli-tool-latex-docs.md)
+[Lab: Bash automation](2026-02/docs/labs/week-1/03-bash-daily-project-summary.md)
 
----
+</div>
+</details>
 
+<details class="tds-week">
+<summary>Week 2: Deployment & API Engineering</summary>
 
+- [FastAPI Fundamentals](2026-02/docs/week-2/01-fastapi.md)
+- [CORS & Middleware](2026-02/docs/week-2/02-cors-middleware.md)
+- [Google OAuth 2.0](2026-02/docs/week-2/03-google-oauth.md)
+- [FastAPI Advanced](2026-02/docs/week-2/04-fastapi-advanced.md)
+- [Config Management](2026-02/docs/week-2/05-config-management.md)
+- [Docker & Compose](2026-02/docs/week-2/06-docker-compose.md)
+- [Deployment Platforms](2026-02/docs/week-2/07-deployment-platforms.md)
+- [Logging & Testing](2026-02/docs/week-2/08-logging-testing.md)
+- [Observability](2026-02/docs/week-2/09-observability.md)
+- [Cloudflare Tunnels](2026-02/docs/week-2/10-cloudflare-tunnels.md)
+- [Local LLMs](2026-02/docs/week-2/11-local-llms.md)
+- [Redis Caching](2026-02/docs/week-2/12-redis-caching.md)
+
+<div class="tds-link">
+
+[Lab: Publish a Gemma model API](2026-02/docs/labs/week-2/gemma-api-hf-spaces-google-auth.md)
+[Lab: Add full observability](2026-02/docs/labs/week-2/fastapi-observability-grafana.md)
+
+</div>
+</details>
+
+<details class="tds-week">
+<summary>Week 3: LLM Engineering</summary>
+
+- [Prompt Engineering](2026-02/docs/week-3/prompt-engineering.md)
+- [Context Engineering](2026-02/docs/week-3/context-engineering.md)
+- [Prompt Caching](2026-02/docs/week-3/prompt-caching.md)
+- [Structured Output](2026-02/docs/week-3/structured-output.md)
+- [LLM Architecture Survey](2026-02/docs/week-3/llm-architecture-survey.md)
+- [Multimodal Inputs](2026-02/docs/week-3/multimodal-inputs.md)
+- [Vector Embeddings](2026-02/docs/week-3/vector-embeddings.md)
+- [Similarity Search](2026-02/docs/week-3/similarity-search.md)
+- [LLM CLI Tools](2026-02/docs/week-3/llm-cli-tools.md)
+- [AI Coding Assistants](2026-02/docs/week-3/ai-coding-assistants.md)
+- [LangSmith & LiteLLM](2026-02/docs/week-3/langsmith-litellm.md)
+
+<div class="tds-link">
+
+[Lab: YouTube → Subtitles → Topics pipeline](2026-02/docs/labs/week-3/youtube-subtitles-topics-json-pipeline.md)
+[Lab: Cost-tracking dashboard](2026-02/docs/labs/week-3/cost-tracking-dashboard-langsmith.md)
+
+</div>
+</details>
+
+<details class="tds-week">
+<summary>Week 4: RAG & Hybrid RAG</summary>
+
+- [Vector Databases](2026-02/docs/week-4/vector-databases.md)
+- [Chunking Strategies](2026-02/docs/week-4/chunking-strategies.md)
+- [Late Chunking](2026-02/docs/week-4/late-chunking.md)
+- [Contextual Retrieval](2026-02/docs/week-4/contextual-retrieval.md)
+- [Hybrid Search](2026-02/docs/week-4/hybrid-search.md)
+- [Reranking](2026-02/docs/week-4/reranking.md)
+- [Query Augmentation](2026-02/docs/week-4/query-augmentation.md)
+- [Semantic Caching](2026-02/docs/week-4/semantic-caching.md)
+- [Multimodal Embeddings](2026-02/docs/week-4/multimodal-embeddings.md)
+- [GraphRAG](2026-02/docs/week-4/graphrag.md)
+- [LLM Grounding & Citations](2026-02/docs/week-4/llm-grounding.md)
+- [RAGAS Evaluation](2026-02/docs/week-4/ragas-evaluation.md)
+
+<div class="tds-link">
+
+[Lab: RAGAS evaluation dashboard](2026-02/docs/labs/week-4/ragas-evaluation-dashboard.md)
+[Capstone: BS Degree Chatbot](2026-02/docs/labs/week-4/capstone-bs-degree-chatbot.md)
+[Capstone: Policy Chatbot](2026-02/docs/labs/week-4/capstone-policy-chatbot.md)
+
+</div>
+</details>
+
+<div class="tds-link">
+
+[Project 1](2026-02/docs/projects/01-project-1.md)
+
+</div>
+
+<details class="tds-week">
+<summary>Week 5: Agentic AI</summary>
+
+- [Agent Fundamentals](2026-02/docs/week-5/agent-fundamentals.md)
+- [Tool / Function Calling](2026-02/docs/week-5/tool-calling.md)
+- [Agent Memory Systems](2026-02/docs/week-5/agent-memory-systems.md)
+- [LangGraph](2026-02/docs/week-5/langgraph.md)
+- [Multi-Agent Systems](2026-02/docs/week-5/multi-agent-systems.md)
+- [Specialized Agents](2026-02/docs/week-5/specialized-agents.md)
+- [Model Context Protocol (MCP)](2026-02/docs/week-5/mcp.md)
+- [Custom MCP Servers](2026-02/docs/week-5/custom-mcp-servers.md)
+- [Async & Parallelism](2026-02/docs/week-5/async-parallelism.md)
+- [LXD Sandboxing](2026-02/docs/week-5/lxd-sandboxing.md)
+- [Agent Evaluation](2026-02/docs/week-5/agent-evaluation.md)
+
+<div class="tds-link">
+
+[Lab: Context-based extraction tool](2026-02/docs/labs/week-5/context-based-extraction-tool.md)
+[Capstone: Autonomous Research Agent](2026-02/docs/labs/week-5/capstone-autonomous-research-agent.md)
+[Capstone: VivaAgent — AI Oral Examiner](2026-02/docs/labs/week-5/capstone-vivaagent-oral-examiner.md)
+
+</div>
+</details>
+
+<details class="tds-week">
+<summary>Week 6: Web Scraping & Data Processing</summary>
+
+- [Playwright & Selenium](2026-02/docs/week-6/playwright-selenium.md)
+- [Scrapy](2026-02/docs/week-6/scrapy.md)
+- [Anti-bot Patterns](2026-02/docs/week-6/anti-bot-patterns.md)
+- [Crawl4AI](2026-02/docs/week-6/crawl4ai.md)
+- [Firecrawl & Apify](2026-02/docs/week-6/firecrawl-apify.md)
+- [Vision Models for Scraping](2026-02/docs/week-6/vision-models-for-scraping.md)
+- [Document Parsing](2026-02/docs/week-6/document-parsing.md)
+- [DuckDB + Parquet](2026-02/docs/week-6/duckdb-parquet.md)
+- [Image Processing Pipeline](2026-02/docs/week-6/image-processing-pipeline.md)
+- [Speech AI](2026-02/docs/week-6/speech-ai.md)
+- [Video Understanding](2026-02/docs/week-6/video-understanding.md)
+- [Firestore Database](2026-02/docs/week-6/firestore.md)
+- [Scheduled Scraping](2026-02/docs/week-6/scheduled-scraping.md)
+- [LLM Architecture](2026-02/docs/week-6/llm-architecture.md)
+
+<div class="tds-link">
+
+[Lab: Scheduled scraper with GitHub Actions](2026-02/docs/labs/week-6/scheduled-scraper-github-actions-cron.md)
+[Capstone: Job Posting Scraper](2026-02/docs/labs/week-6/capstone-job-posting-scraper-tracker.md)
+[Capstone: AI Signature Detection](2026-02/docs/labs/week-6/capstone-ai-signature-detection-cropper.md)
+[Capstone: Live Multilingual Translator](2026-02/docs/labs/week-6/capstone-live-multilingual-travel-translator.md)
+
+</div>
+</details>
+
+<details class="tds-week">
+<summary>Week 7: CI/CD, Security & Cloud</summary>
+
+- [GitHub Actions Advanced](2026-02/docs/week-7/01-github-actions-advanced.md)
+- [Advanced Docker](2026-02/docs/week-7/02-advanced-docker.md)
+- [Serverless Functions](2026-02/docs/week-7/07-serverless-functions.md)
+- [LLM Security — Offensive](2026-02/docs/week-7/03-llm-security-offensive.md)
+- [LLM Safety — Defensive](2026-02/docs/week-7/04-llm-safety-defensive.md)
+- [OWASP LLM Top 10](2026-02/docs/week-7/05-owasp-llm-top-10.md)
+- [VMs & SSH](2026-02/docs/week-7/06-vms-ssh.md)
+- [Terraform & IaC](2026-02/docs/week-7/08-terraform-iac.md)
+- [Cost Alerting & Budgets](2026-02/docs/week-7/09-cost-alerting.md)
+- [Pub/Sub & Event-Driven](2026-02/docs/week-7/10-pubsub-event-driven.md)
+
+<div class="tds-link">
+
+[Lab: Red-team your own API](2026-02/docs/labs/week-7/01-red-team-your-api-guardrails.md)
+[Lab: Full CI/CD to Cloud Run](2026-02/docs/labs/week-7/02-full-cicd-cloud-run.md)
+
+</div>
+</details>
+
+<details class="tds-week">
+<summary>Week 8: MLOps & Fine-Tuning</summary>
+
+- [Cloud Storage for ML](2026-02/docs/week-8/01-cloud-storage-ml.md)
+- [BigQuery ML](2026-02/docs/week-8/02-bigquery-ml.md)
+- [GCP ML Pipeline](2026-02/docs/week-8/09-gcp-ml-pipeline.md)
+- [MLflow](2026-02/docs/week-8/03-mlflow.md)
+- [Fine-Tuning Strategy](2026-02/docs/week-8/04-finetuning-strategy.md)
+- [HuggingFace Ecosystem](2026-02/docs/week-8/05-huggingface-ecosystem.md)
+- [Fine-Tuning Techniques](2026-02/docs/week-8/06-finetuning-techniques.md)
+- [Quantization](2026-02/docs/week-8/07-quantization.md)
+- [Gemma 4 Fine-Tuning](2026-02/docs/week-8/08-gemma4-finetuning.md)
+- [Model Publishing & Cards](2026-02/docs/week-8/10-model-publishing.md)
+
+<div class="tds-link">
+
+[Lab: Full GCP pipeline](2026-02/docs/labs/week-8/02-full-gcp-pipeline-bqml-vertex-cloud-run.md)
+[Capstone: Production Fine-Tuned Model](2026-02/docs/labs/week-8/01-capstone-production-finetuned-model-mlops.md)
+
+</div>
+</details>
+
+<div class="tds-link">
+
+[Project 2](2026-02/docs/projects/02-project-2.md)
+
+</div>
+
+<details class="tds-week">
+<summary>Reference</summary>
+
+- [Tools Glossary](2026-02/docs/reference/01-tools-glossary.md)
+- [Command Cheatsheet](2026-02/docs/reference/02-command-cheatsheet.md)
+- [All Lab Assignments](2026-02/docs/labs/all-lab-assignments.md)
+- [All Capstone Projects](2026-02/docs/labs/capstone-projects.md)
+
+</details>

--- a/hugo/assets/_custom.scss
+++ b/hugo/assets/_custom.scss
@@ -7,24 +7,90 @@ html[data-user-theme="dark"] {
   @include theme-dark;
 }
 
-// Sidebar theme toggle button styling.
+// Sidebar theme toggle button styled as centered plain text.
 .tds-theme-toggle {
-  margin-top: 1rem;
-  width: 100%;
-  border: 1px solid var(--gray-400);
-  border-radius: 0.375rem;
-  background: var(--body-background);
-  color: var(--body-font-color);
-  padding: 0.5rem 0.625rem;
-  font-size: 0.875rem;
-  cursor: pointer;
-}
-
-.tds-theme-toggle:hover {
-  border-color: var(--color-link);
-}
-
-.book-menu-content a.active {
+  display: block;
+  margin: 1.5rem auto 0 auto;
+  padding: 0.5rem 1rem;
+  border: none;
+  background: transparent;
   color: var(--color-link);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-align: center;
+  width: auto;
+}
+.tds-theme-toggle:hover {
+  text-decoration: underline;
+}
+.container {
+  max-width: none;
+  margin: 0;
+}
+
+.book-menu-content nav > ul > li {
+  margin: 0.55rem 0;
+}
+.book-menu-content .tds-week {
+  margin: 0.55rem 0;
+  border-bottom: 1px solid var(--gray-200);
+  padding-bottom: 0.4rem;
+}
+.book-menu-content .tds-week summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  cursor: pointer;
+  font-weight: 600;
+  line-height: 1.35;
+}
+.book-menu-content .tds-week summary::-webkit-details-marker {
+  display: none;
+}
+.book-menu-content .tds-week summary::after {
+  content: "+";
+}
+.book-menu-content .tds-week[open] summary::after {
+  content: "-";
+}
+.book-menu-content .tds-week ul {
+  border-left: 2px solid var(--gray-200);
+  margin: 0.6rem 0 0 0.15rem;
+  padding-inline-start: 0.85rem;
+}
+// Milestone links (projects, ROE, and resource shortcuts) shown as pill rows.
+.book-menu-content .tds-link ul {
+  list-style: none;
+  margin: 0.55rem 0;
+  padding: 0;
+}
+.book-menu-content .tds-link li {
+  margin: 0.35rem 0;
+}
+.book-menu-content .tds-link a {
+  display: block;
+  padding: 0.4rem 0.7rem;
+  border: 1px solid var(--gray-200);
+  border-radius: 0.4rem;
+  background: var(--gray-100);
+  color: var(--body-font-color);
   font-weight: 600;
 }
+.book-menu-content .tds-link a:hover,
+.book-menu-content .tds-link a.active {
+  border-color: var(--color-link);
+  color: var(--color-link);
+}
+.book-menu-content::-webkit-scrollbar {
+  width: 0.5rem;
+}
+.book-menu-content::-webkit-scrollbar-thumb {
+  background: transparent;
+  border-radius: 0.5rem;
+}
+.book-menu-content:hover::-webkit-scrollbar-thumb {
+  background: var(--gray-500);
+}
+

--- a/hugo/layouts/_partials/docs/inject/menu-after.html
+++ b/hugo/layouts/_partials/docs/inject/menu-after.html
@@ -40,6 +40,15 @@
       if (normalize(href) === current) {
         a.classList.add("active");
         a.setAttribute("aria-current", "page");
+
+        // Auto-expand the parent <details> folders of the active link
+        var parent = a.parentElement;
+        while (parent && parent !== document.body) {
+          if (parent.tagName === "DETAILS") {
+            parent.open = true;
+          }
+          parent = parent.parentElement;
+        }
       }
     });
   })();

--- a/hugo/layouts/_partials/docs/menu-filetree.html
+++ b/hugo/layouts/_partials/docs/menu-filetree.html
@@ -9,5 +9,9 @@
 {{ end }}
 
 {{ $sidebarFile := printf "sidebars/%s.md" $sidebar }}
+{{ if not (fileExists $sidebarFile) }}
+  {{ $sidebarFile = "sidebars/root.md" }}
+{{ end }}
 {{ $sidebarMarkdown := readFile $sidebarFile }}
-{{ $sidebarMarkdown | markdownify }}
+{{- $basePath := .Site.BaseURL | strings.TrimSuffix "/" -}}
+{{ $sidebarMarkdown | markdownify | replaceRE `href="(/[^"]*)"` (printf `href="%s$1"` $basePath) | safeHTML }}

--- a/marks-dashboard.md
+++ b/marks-dashboard.md
@@ -6,7 +6,7 @@ The final score for the course is calculated as follows:
 
 | Components (All out of 100)              | Weight |
 | ---------------------------------------- | ------ |
-| Grade Assessments **(GA)** <br> Best 5/8 | 20%    |
+| Grade Assessments **(GA)** <br> Best 7/9 | 20%    |
 | Project 1 **(P1)**                       | 20%    |
 | Project 2 **(P2)**                       | 20%    |
 | Remote Online Exam **(ROE)**             | 20%    |
@@ -18,6 +18,10 @@ T = 0.2 GA + 0.2 P1 + 0.2 P2 + 0.2 ROE + 0.2 ET
 
 > Note: The scores are updated one to two days after the deadline for the GAs and ROEs. Score updates for Projects can take more than a week or two due to large evaluation time frames.
 
+- Live Session (Recording/Live) : https://www.youtube.com/@se-lr5ff (see in live section)
+- All ga & roe will happen on : http://exam.sanand.workers.dev/
+- Submit feedback every week to improve the course.
+
 The scores for your various components are available at this link. You must login with your student id to view them.
 
-### [Open the score dashboard](https://lookerstudio.google.com/reporting/f697ff2b-9b0c-4df9-8aed-f6998a2977ff)
+### [Open the score dashboard: (To be Updated)](https://lookerstudio.google.com/reporting/f697ff2b-9b0c-4df9-8aed-f6998a2977ff)

--- a/marks-dashboard.md
+++ b/marks-dashboard.md
@@ -19,9 +19,9 @@ T = 0.2 GA + 0.2 P1 + 0.2 P2 + 0.2 ROE + 0.2 ET
 > Note: The scores are updated one to two days after the deadline for the GAs and ROEs. Score updates for Projects can take more than a week or two due to large evaluation time frames.
 
 - Live Session (Recording/Live) : https://www.youtube.com/@se-lr5ff (see in live section)
-- All ga & roe will happen on : http://exam.sanand.workers.dev/
+- GAs & ROE will be on : https://exam.sanand.workers.dev/
 - Submit feedback every week to improve the course.
 
 The scores for your various components are available at this link. You must login with your student id to view them.
 
-### [Open the score dashboard: (To be Updated)](https://lookerstudio.google.com/reporting/f697ff2b-9b0c-4df9-8aed-f6998a2977ff)
+### [Open the score dashboard (link to be updated)](https://lookerstudio.google.com/reporting/f697ff2b-9b0c-4df9-8aed-f6998a2977ff)


### PR DESCRIPTION
Update course to May 2026 term + revamp sidebar navigation

Summary

Rolls the course over to the May 2026 term and reworks the sidebar into a collapsible, tree-style navigation with pill-styled milestone links.

Course content (README.md, marks-dashboard.md, 2026-01/README.md)

- Updated title, term labels, and all course/announcement/grading links from Jan 2026 → May 2026.
- Reworked the schedule table: new GA0 Bootcamp, restructured to best 7 of 9 GAs, added a Feedback column with per-week feedback links, and refreshed all release/submission dates.
- Replaced the picoCTF-based P2A/P2B split with a single Project 2, and updated the readiness check from GA1 → GA0.
- Refreshed the Resources and Contacts tables (new TAs, course/announcement pages, grading doc), fixed several typos, and noted no content for the Jan 2026 term.
- Updated marks-dashboard.md weighting (Best 7/9) and added live-session / exam / feedback pointers.

Sidebar navigation (_sidebar.md, hugo/...)

- Converted the flat bullet list into collapsible <details> sections per week (.tds-week), with a custom +/- marker and a nested tree border.
- Styled standalone milestone links — Marks Dashboard, Project 1, Project 2 — and lab/capstone links as pill rows (.tds-link).
- menu-after.html: active link now auto-expands its parent folders so the current page is always visible.
- menu-filetree.html: falls back to sidebars/root.md when a per-section sidebar is missing, and rewrites root-relative links with the site baseURL so they work under a subpath.
- Restyled the theme-toggle button as centered plain text and added sidebar scrollbar styling.
